### PR TITLE
Using random_int to generate cryptographic random

### DIFF
--- a/src/Generator/Passcode.php
+++ b/src/Generator/Passcode.php
@@ -20,7 +20,7 @@ class Passcode
     {
         $code = [];
         for ($amount = 0; $amount < $length; $amount++) {
-            $code[] = self::DIGITS[mt_rand(0, self::TOTAL_DIGITS)];
+            $code[] = self::DIGITS[random_int(0, self::TOTAL_DIGITS)];
         }
 
         return implode($code);


### PR DESCRIPTION
# Changed log

- To generate the random integers cryptographically, using the `random_int` to replace the `mt_rand` function.