### PR TITLE
Using the random_int to improve array_rand

### DIFF
--- a/src/Generator/Password.php
+++ b/src/Generator/Password.php
@@ -23,9 +23,10 @@ class Password
             range('Z', 'Z'),
             $specialCharacters ? self::SPECIAL_CHARACTERS : []
         );
+        $endKeysIndex = count($keys) - 1;
 
         for ($amount = 0; $amount < $length; $amount++) {
-            $password .= $keys[array_rand($keys)];
+            $password .= $keys[random_int(0, $endKeysIndex)];
         }
 
         return $password;


### PR DESCRIPTION
# Changed log

- According to the [reply](https://github.com/pH-7/passcode-password-generator/pull/3#issuecomment-1330448924), it should use the `random_int` to replace the `array_rand` function.