### PR TITLE
Fix Invalid Range Definition

### DIFF
--- a/src/Generator/Password.php
+++ b/src/Generator/Password.php
@@ -21,7 +21,7 @@ class Password
         $keys = array_merge(
             range(0, 9),
             range('a', 'z'),
-            range('Z', 'Z'),
+            range('A', 'Z'),
             $specialCharacters ? self::SPECIAL_CHARACTERS : []
         );
         $endKeysIndex = count($keys) - 1;


### PR DESCRIPTION
This PR fixes an issue in the PHP password generator where the range definition was incorrectly set to `range('Z', 'Z')`, which resulted in an array containing only `['Z']`. The correct range should be `range('A', 'Z')` to properly include all uppercase letters from A to Z.  

**Changes:**  
- Updated `range('Z', 'Z')` to `range('A', 'Z')` to correctly generate the intended character set.  